### PR TITLE
Add OverlayRenderMethod with oca-bundle-v2 render suite

### DIFF
--- a/index.html
+++ b/index.html
@@ -1377,15 +1377,15 @@ via `port` with the error message.
       <p>
         When OCA is used as a render method for [=verifiable credentials=], the capture
         base in the OCA Bundle uses JSON paths (as defined in [[[RFC6901]]]) as attribute
-        names to reference properties within the [=verifiable credential=]'s
-        `credentialSubject`, and defines the data type for each attribute. For example,
-        an attribute named `/degree/name` would reference the `name` property within
-        the nested `degree` object of the credential subject. The overlays then provide
-        presentation metadata such as human-readable labels in multiple languages,
-        formatting rules for dates and numbers, constraints for data entry, and
-        descriptive information about each attribute. This separation allows the same
-        credential data to be rendered differently based on context, locale, or user
-        preferences while maintaining a consistent semantic foundation.
+        names to reference properties from the root of the [=verifiable credential=]
+        document, and defines the data type for each attribute. For example,
+        an attribute named `/credentialSubject/degree/name` would reference the `name` 
+        property within the nested `degree` object of the credential's `credentialSubject`.
+        The overlays then provide presentation metadata such as human-readable labels in 
+        multiple languages, formatting rules for dates and numbers, constraints for data 
+        entry, and descriptive information about each attribute. This separation allows 
+        the same credential data to be rendered differently based on context, locale, or 
+        user preferences while maintaining a consistent semantic foundation.
       </p>
 
       <p>
@@ -1518,10 +1518,10 @@ processing logic for the OCA Bundle format.
       "digest": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
       "type": "spec/capture_base/2.0.0",
       "attributes": {
-        "/degree/type": "Text",
-        "/degree/name": "Text",
-        "/degree/degreeType": "Text",
-        "/degree/major": "Text"
+        "/credentialSubject/degree/type": "Text",
+        "/credentialSubject/degree/name": "Text",
+        "/credentialSubject/degree/degreeType": "Text",
+        "/credentialSubject/degree/major": "Text"
       },
       "classification": ""
     },
@@ -1539,10 +1539,10 @@ processing logic for the OCA Bundle format.
         "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
         "language": "en",
         "attribute_labels": {
-          "/degree/type": "Degree Type",
-          "/degree/name": "Degree Name",
-          "/degree/degreeType": "Degree Classification",
-          "/degree/major": "Major"
+          "/credentialSubject/degree/type": "Degree Type",
+          "/credentialSubject/degree/name": "Degree Name",
+          "/credentialSubject/degree/degreeType": "Degree Classification",
+          "/credentialSubject/degree/major": "Major"
         }
       },
       {
@@ -1551,10 +1551,10 @@ processing logic for the OCA Bundle format.
         "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
         "language": "fr",
         "attribute_labels": {
-          "/degree/type": "Type de diplôme",
-          "/degree/name": "Nom du diplôme",
-          "/degree/degreeType": "Classification du diplôme",
-          "/degree/major": "Spécialisation"
+          "/credentialSubject/degree/type": "Type de diplôme",
+          "/credentialSubject/degree/name": "Nom du diplôme",
+          "/credentialSubject/degree/degreeType": "Classification du diplôme",
+          "/credentialSubject/degree/major": "Spécialisation"
         }
       },
       {
@@ -1563,10 +1563,10 @@ processing logic for the OCA Bundle format.
         "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
         "language": "en",
         "attribute_information": {
-          "/degree/type": "The type of academic degree awarded",
-          "/degree/name": "The full official name of the degree",
-          "/degree/degreeType": "Classification level (e.g., Undergraduate, Graduate)",
-          "/degree/major": "The primary field of study"
+          "/credentialSubject/degree/type": "The type of academic degree awarded",
+          "/credentialSubject/degree/name": "The full official name of the degree",
+          "/credentialSubject/degree/degreeType": "Classification level (e.g., Undergraduate, Graduate)",
+          "/credentialSubject/degree/major": "The primary field of study"
         }
       },
       {
@@ -1574,7 +1574,7 @@ processing logic for the OCA Bundle format.
         "type": "spec/overlays/sensitive/2.0.0",
         "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
         "attributes": [
-          "/degree/name"
+          "/credentialSubject/degree/name"
         ]
       }
     ]

--- a/index.html
+++ b/index.html
@@ -300,7 +300,7 @@ The value of the `renderMethod` property MUST specify one or
 more rendering methods that can be used by software to express the
 [=verifiable credential=] using a visual, auditory, or haptic mechanism. Each
 `renderMethod` value MUST specify its `type`, for example,
-`TemplateRenderMethod`, `OpenAttestationEmbeddedRenderer`, or `OCABundle`.
+`TemplateRenderMethod`, `OverlayRenderMethod`, or `EmbeddedRenderer`.
 The precise contents of each rendering hint is determined by the specific
 `renderMethod` `type` definition.
           </dd>
@@ -1028,10 +1028,289 @@ via `port` with the error message.
       </section>
     </section>
 
+      <section>
+        <h4>OverlayRenderMethod</h4>
 
+        <p>
+OverlayRenderMethod is used by an [=issuer=] to link a [=verifiable credential=]
+to an external package of presentation metadata&mdash;such as an Overlays Capture
+Architecture (OCA) Bundle [[[OCA]]]&mdash;without prescribing a single visual
+template. A capture base describes credential attributes (often as JSON Pointer
+[[RFC6901]] paths from the document root), and overlays supply labels, formats,
+sensitive-data flags, and related presentation rules. Renderers use this
+information to build user interfaces, select locales, and display fields
+consistently across applications.
+        </p>
 
+        <p>
+When an [=issuer=] desires to specify overlay-based rendering instructions
+for a [=verifiable credential=], they MAY add a `renderMethod` property that uses
+the data model described below.
+        </p>
 
+        <table class="simple">
+          <thead>
+            <tr>
+              <th style="white-space: nowrap">Property</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>id</td>
+              <td>
+An OPTIONAL [=string=] that follows the [[[URL]]] specification and, when
+fetched, dereferences to a complete `OverlayRenderMethod` value. When `bundle`
+is present, this property MAY be omitted.
+              </td>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>
+A REQUIRED [=string=] that MUST be the value `OverlayRenderMethod`.
+              </td>
+            </tr>
+            <tr>
+              <td>renderSuite</td>
+              <td>
+A REQUIRED [=string=] that identifies the overlay package format and processing
+algorithm. The `oca-bundle-v2` render suite is defined in this specification.
+              </td>
+            </tr>
+            <tr>
+              <td>name</td>
+              <td>
+An OPTIONAL human-readable [=string=] that can be displayed to provide a hint to
+the type of rendering that will be performed. This property might be used in a
+graphical interface that enables an individual to select between multiple
+presentation modes.
+              </td>
+            </tr>
+            <tr>
+              <td>description</td>
+              <td>
+An OPTIONAL human-readable [=string=] that provides a more detailed description
+of the overlay-based rendering method and when it might be useful.
+              </td>
+            </tr>
+            <tr>
+              <td>renderProperty</td>
+              <td>
+An OPTIONAL [=list=] of [=string=] values that each conform to the
+[[[RFC6901]]] syntax that specifies which properties from the [=verifiable
+credential=] are exposed when using this specific render method. If
+`renderProperty` is not provided, the entire [=verifiable credential=] is
+presumed to be available to the overlay renderer.
+              </td>
+            </tr>
+            <tr>
+              <td>bundle</td>
+              <td>
+An OPTIONAL [=URL=] or [=ordered map|map=] that provides or refers to the
+overlay package used for rendering. If the value is a [=URL=], it MUST
+dereference to an overlay bundle document (for the `oca-bundle-v2` render suite,
+an OCA Bundle in JSON format with media type `application/json`). If the value
+is a [=ordered map|map=], it MUST conform to the following rules:
+                <table class="simple">
+                  <thead>
+                    <tr>
+                      <th style="white-space: nowrap">Property</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>id</td>
+                      <td>
+A REQUIRED [=string=] that follows the [[[URL]]] specification and, when
+fetched, dereferences to the overlay bundle.
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>mediaType</td>
+                      <td>
+A RECOMMENDED [=string=] that identifies the media type for the `id` value
+as specified in [[[RFC6838]]]. For the `oca-bundle-v2` render suite, the value
+SHOULD be `application/json`.
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>digestMultibase</td>
+                      <td>
+An OPTIONAL multibase-encoded Multihash of the overlay bundle. The multibase
+value MUST be `u` (base64url-nopad) and the multihash value MUST be SHA-2 with
+256-bits of output (`0x12`).
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td>digestMultibase</td>
+              <td>
+An OPTIONAL multibase-encoded Multihash of the overlay render method referenced
+if `id` is specified. The multibase value MUST be `u` (base64url-nopad) and the
+multihash value MUST be SHA-2 with 256-bits of output (`0x12`).
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
+        <p>
+The data model shown above is expressed in a [=verifiable credential=] in the
+example below.
+        </p>
+
+        <pre
+          class="example nohighlight"
+          title="Usage of OverlayRenderMethod with the oca-bundle-v2 render suite"
+        >
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2",
+    "https://w3id.org/vc/render-method/v1"
+  ],
+  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": {
+    "id": "https://example.edu/issuers/565049",
+    "name": "Example University"
+  },
+  "validFrom": "2024-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science and Arts",
+      "degreeType": "Undergraduate",
+      "major": "Computer Science"
+    }
+  },
+  <span class="highlight">"renderMethod": [{
+    "type": "OverlayRenderMethod",
+    "renderSuite": "oca-bundle-v2",
+    "bundle": {
+      "id": "https://example.edu/oca-bundles/degree-2024.json",
+      "mediaType": "application/json",
+      "digestMultibase": "uEiC96D8xPcVfm...WNcMF4Kc-Yw"
+    },
+    "name": "University Degree Display",
+    "description": "Renders the degree credential with multi-language support"
+  }]</span>
+}
+        </pre>
+
+        <section>
+          <h3>The `oca-bundle-v2` Render Suite</h3>
+
+          <p>
+The `oca-bundle-v2` render suite uses an OCA Bundle as defined in [[[OCA]]].
+The bundle contains a capture base and overlays. For this render suite,
+`renderSuite` MUST be the value `oca-bundle-v2`, and `bundle` MUST be present
+either as a URL or as a map with an `id` that dereferences to the bundle.
+          </p>
+
+          <p>
+When processing this render suite, attribute names in the capture base MUST be
+interpreted as JSON Pointer paths [[RFC6901]] from the root of the
+[=verifiable credential=] document unless otherwise specified by [[[OCA]]].
+For example, an attribute named `/credentialSubject/degree/name` references
+the `name` property within the `degree` object of `credentialSubject`. Overlays
+in the bundle provide presentation metadata such as human-readable labels in
+multiple languages, formatting rules, and sensitive-data flags for those
+attributes.
+          </p>
+
+          <p>
+An example OCA Bundle structure for the credential above might look like:
+          </p>
+
+          <pre
+            class="example nohighlight"
+            title="Example OCA Bundle structure with JSON path attributes"
+          >
+{
+  "bundle": {
+    "v": "OCAS11JSON000646_",
+    "digest": "EBfdlu8R27Fbx-ehrqwIxQ-na4B7A4LqidzXqj8gkzHp",
+    "capture_base": {
+      "digest": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+      "type": "spec/capture_base/2.0.0",
+      "attributes": {
+        "/credentialSubject/degree/type": "Text",
+        "/credentialSubject/degree/name": "Text",
+        "/credentialSubject/degree/degreeType": "Text",
+        "/credentialSubject/degree/major": "Text"
+      },
+      "classification": ""
+    },
+    "overlays": [
+      {
+        "digest": "EMzAk6N2iI1K5EpS9YqU7WxTc8BvPq1RgFn0D4XyJwLz",
+        "type": "spec/overlays/meta/2.0.0",
+        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+        "name": "University Degree Credential",
+        "description": "Academic degree credential issued by universities"
+      },
+      {
+        "digest": "EJqWh3K9fF8H2BmP6VnR4TxQz5YsLm8NcDk7A1UvGtIw",
+        "type": "spec/overlays/label/2.0.0",
+        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+        "language": "en",
+        "attribute_labels": {
+          "/credentialSubject/degree/type": "Degree Type",
+          "/credentialSubject/degree/name": "Degree Name",
+          "/credentialSubject/degree/degreeType": "Degree Classification",
+          "/credentialSubject/degree/major": "Major"
+        }
+      },
+      {
+        "digest": "EKpXi4L0gG9I3CnQ7WoS5UyRa6ZtNo9OdEl8B2VwHuJx",
+        "type": "spec/overlays/label/2.0.0",
+        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+        "language": "fr",
+        "attribute_labels": {
+          "/credentialSubject/degree/type": "Type de diplôme",
+          "/credentialSubject/degree/name": "Nom du diplôme",
+          "/credentialSubject/degree/degreeType": "Classification du diplôme",
+          "/credentialSubject/degree/major": "Spécialisation"
+        }
+      },
+      {
+        "digest": "ELrYj5M1hH0J4DoR8XpT6VzSb7AuOp0QeFm9C3WxIvKy",
+        "type": "spec/overlays/information/2.0.0",
+        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+        "language": "en",
+        "attribute_information": {
+          "/credentialSubject/degree/type": "The type of academic degree awarded",
+          "/credentialSubject/degree/name": "The full official name of the degree",
+          "/credentialSubject/degree/degreeType": "Classification level (e.g., Undergraduate, Graduate)",
+          "/credentialSubject/degree/major": "The primary field of study"
+        }
+      },
+      {
+        "digest": "ENaZl7O3jJ2L6FqT0ZrV8XyUd9CwRs2ShGo1E5YzKxMa",
+        "type": "spec/overlays/sensitive/2.0.0",
+        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+        "attributes": [
+          "/credentialSubject/degree/name"
+        ]
+      }
+    ]
+  }
+}
+          </pre>
+
+          <p>
+Implementers use the bundle to generate appropriate user interfaces, select
+language-specific labels, apply format specifications, and ensure consistent
+rendering across applications. A [=verifiable credential=] MAY include both an
+`OverlayRenderMethod` and a `TemplateRenderMethod`; in that case, the overlay
+package can supply labels and metadata while a template supplies layout.
+          </p>
+        </section>
+      </section>
 
     <!-- OpenAttestationEmbeddedRenderer -->
     <section>
@@ -1352,242 +1631,6 @@ via `port` with the error message.
             </section>
         </section>
     </section>
-
-    <section>
-      <h4>OCABundle</h4>
-
-      <p>
-        OCABundle is used by an issuer to specify rendering instructions
-        based on an Overlays Capture Architecture (OCA) Bundle as defined in [[[OCA]]].
-        OCA provides a standardized way to define schemas with semantic overlays that
-        enable multi-language support, data entry formats, sensitive data flagging, and
-        rich metadata for rendering verifiable credentials in a consistent and
-        interoperable manner.
-      </p>
-
-      <p>
-        An OCA Bundle consists of a capture base that defines the core structure
-        and data types of the credential attributes, along with various overlays
-        that provide additional context such as labels, character encoding, format
-        specifications, entry codes, and information overlays. This layered approach
-        enables flexible and culturally-aware rendering of credentials while maintaining
-        data integrity.
-      </p>
-
-      <p>
-        When OCA is used as a render method for [=verifiable credentials=], the capture
-        base in the OCA Bundle uses JSON paths (as defined in [[[RFC6901]]]) as attribute
-        names to reference properties from the root of the [=verifiable credential=]
-        document, and defines the data type for each attribute. For example,
-        an attribute named `/credentialSubject/degree/name` would reference the `name` 
-        property within the nested `degree` object of the credential's `credentialSubject`.
-        The overlays then provide presentation metadata such as human-readable labels in 
-        multiple languages, formatting rules for dates and numbers, constraints for data 
-        entry, and descriptive information about each attribute. This separation allows 
-        the same credential data to be rendered differently based on context, locale, or 
-        user preferences while maintaining a consistent semantic foundation.
-      </p>
-
-      <p>
-        When an [=issuer=] desires to specify OCA-based rendering instructions
-        for a [=verifiable credential=], they MAY add a `renderMethod` property
-        that uses the data model described below.
-      </p>
-
-      <table class="simple">
-        <thead>
-          <tr>
-            <th style="white-space: nowrap">Property</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>id</td>
-            <td>
-A REQUIRED [=string=] that follows the [[[URL]]] specification and, when fetched,
-dereferences to an OCA Bundle in JSON format. The OCA Bundle contains the capture
-base and associated overlays needed for rendering the credential.
-            </td>
-          </tr>
-          <tr>
-            <td>type</td>
-            <td>
-A REQUIRED [=string=] that MUST be the value `OCABundle`.
-            </td>
-          </tr>
-          <tr>
-            <td>name</td>
-            <td>
-An OPTIONAL human-readable [=string=] that can be displayed to provide a hint to
-the type of rendering that will be performed. This property might be used in a
-graphical interface that enables an individual to select between multiple
-presentation modes.
-            </td>
-          </tr>
-          <tr>
-            <td>description</td>
-            <td>
-An OPTIONAL human-readable [=string=] that provides a more detailed description
-of the OCA-based rendering method and when it might be useful.
-            </td>
-          </tr>
-          <tr>
-            <td>digestMultibase</td>
-            <td>
-An OPTIONAL multibase-encoded Multihash of the OCA Bundle. The multibase
-value MUST be `u` (base64url-nopad) and the multihash value MUST be SHA-2 with
-256 bits of output (0x12 in the multicodec table). This property can be used by
-verifiers to ensure the integrity of the fetched OCA Bundle.
-            </td>
-          </tr>
-          <tr>
-            <td>version</td>
-            <td>
-An OPTIONAL [=string=] that specifies the OCA specification version that the
-referenced OCA Bundle conforms to (e.g., "v2.0.0-rc1", "v2.0.0", "v1.0").
-This property helps renderers determine compatibility and select appropriate
-processing logic for the OCA Bundle format.
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-      <p>
-        The data model shown above is expressed in a [=verifiable credential=] in
-        the example below.
-      </p>
-
-      <pre
-        class="example nohighlight"
-        title="Usage of OCABundle render method with a remote OCA Bundle"
-      >
-{
-  "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
-  ],
-  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-  "issuer": {
-    "id": "https://example.edu/issuers/565049",
-    "name": "Example University"
-  },
-  "validFrom": "2024-01-01T00:00:00Z",
-  "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    "degree": {
-      "type": "BachelorDegree",
-      "name": "Bachelor of Science and Arts",
-      "degreeType": "Undergraduate",
-      "major": "Computer Science"
-    }
-  },
-  <span class="highlight">"renderMethod": [{
-    "id": "https://example.edu/oca-bundles/degree-2024.json",
-    "type": "OCABundle",
-    "name": "University Degree Display",
-    "description": "Renders the degree credential with multi-language support",
-    "digestMultibase": "uEiC96D8xPcVfm...WNcMF4Kc-Yw",
-    "version": "v2.0.0-rc1"
-  }]</span>
-}
-      </pre>
-
-      <p>
-        In this example, the OCA Bundle located at
-        `https://example.edu/oca-bundles/degree-2024.json` contains the capture
-        base and overlays necessary to render the credential. The bundle might
-        include label overlays for multiple languages, format overlays for date
-        and number formatting, and information overlays with descriptions of each
-        attribute.
-      </p>
-
-      <p>
-        An example OCA Bundle structure for this credential might look like:
-      </p>
-
-      <pre
-        class="example nohighlight"
-        title="Example OCA Bundle structure with JSON path attributes"
-      >
-{
-  "bundle": {
-    "v": "OCAS11JSON000646_",
-    "digest": "EBfdlu8R27Fbx-ehrqwIxQ-na4B7A4LqidzXqj8gkzHp",
-    "capture_base": {
-      "digest": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
-      "type": "spec/capture_base/2.0.0",
-      "attributes": {
-        "/credentialSubject/degree/type": "Text",
-        "/credentialSubject/degree/name": "Text",
-        "/credentialSubject/degree/degreeType": "Text",
-        "/credentialSubject/degree/major": "Text"
-      },
-      "classification": ""
-    },
-    "overlays": [
-      {
-        "digest": "EMzAk6N2iI1K5EpS9YqU7WxTc8BvPq1RgFn0D4XyJwLz",
-        "type": "spec/overlays/meta/2.0.0",
-        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
-        "name": "University Degree Credential",
-        "description": "Academic degree credential issued by universities"
-      },
-      {
-        "digest": "EJqWh3K9fF8H2BmP6VnR4TxQz5YsLm8NcDk7A1UvGtIw",
-        "type": "spec/overlays/label/2.0.0",
-        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
-        "language": "en",
-        "attribute_labels": {
-          "/credentialSubject/degree/type": "Degree Type",
-          "/credentialSubject/degree/name": "Degree Name",
-          "/credentialSubject/degree/degreeType": "Degree Classification",
-          "/credentialSubject/degree/major": "Major"
-        }
-      },
-      {
-        "digest": "EKpXi4L0gG9I3CnQ7WoS5UyRa6ZtNo9OdEl8B2VwHuJx",
-        "type": "spec/overlays/label/2.0.0",
-        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
-        "language": "fr",
-        "attribute_labels": {
-          "/credentialSubject/degree/type": "Type de diplôme",
-          "/credentialSubject/degree/name": "Nom du diplôme",
-          "/credentialSubject/degree/degreeType": "Classification du diplôme",
-          "/credentialSubject/degree/major": "Spécialisation"
-        }
-      },
-      {
-        "digest": "ELrYj5M1hH0J4DoR8XpT6VzSb7AuOp0QeFm9C3WxIvKy",
-        "type": "spec/overlays/information/2.0.0",
-        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
-        "language": "en",
-        "attribute_information": {
-          "/credentialSubject/degree/type": "The type of academic degree awarded",
-          "/credentialSubject/degree/name": "The full official name of the degree",
-          "/credentialSubject/degree/degreeType": "Classification level (e.g., Undergraduate, Graduate)",
-          "/credentialSubject/degree/major": "The primary field of study"
-        }
-      },
-      {
-        "digest": "ENaZl7O3jJ2L6FqT0ZrV8XyUd9CwRs2ShGo1E5YzKxMa",
-        "type": "spec/overlays/sensitive/2.0.0",
-        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
-        "attributes": [
-          "/credentialSubject/degree/name"
-        ]
-      }
-    ]
-  }
-}
-      </pre>
-
-      <p>
-        Implementers can use the OCA Bundle to generate appropriate user interfaces,
-        select language-specific labels, apply format specifications, and ensure
-        consistent rendering across different applications and platforms.
-      </p>
-    </section>
   </section>
 
   <section>
@@ -1607,6 +1650,53 @@ to produce a visual representation of the [=verifiable credential=].
 See the <a href="https://mustache.github.io/mustache.5.html">Mustache 5.0
 Specification</a> for details.
       </p>
+    </section>
+
+    <section>
+      <h3>Render (OverlayRenderMethod)</h3>
+
+      <p>
+The following algorithm applies when `renderMethod.type` is
+`OverlayRenderMethod` and `renderMethod.renderSuite` is `oca-bundle-v2`.
+      </p>
+
+      <ol class="algorithm">
+        <li>
+Let `vc` be the [=verifiable credential=] to render.
+        </li>
+        <li>
+Let `renderMethod` be the chosen `renderMethod` entry where
+`renderMethod.type` is `OverlayRenderMethod` and
+`renderMethod.renderSuite` is `oca-bundle-v2`.
+        </li>
+        <li>
+If `renderMethod.bundle` is a [=string=], let `bundleUrl` be its value.
+Otherwise, if `renderMethod.bundle` is a [=map=], let `bundleUrl` be the value
+of `renderMethod.bundle.id`. Otherwise, if `renderMethod.id` is present, fetch
+it and let the result be the `renderMethod` value; then repeat this step.
+        </li>
+        <li>
+Fetch `bundleUrl` and parse the response as JSON. If
+`renderMethod.bundle.digestMultibase` is present, verify the response against
+that digest prior to use.
+        </li>
+        <li>
+If `renderMethod.renderProperty` is present, let `vcData` be the result of
+applying the `selectJsonLd` algorithm [[VC-DI-ECDSA]] to `vc` using the JSON
+Pointer values in `renderMethod.renderProperty`. Otherwise, let `vcData` be
+`vc`.
+        </li>
+        <li>
+For each attribute name in the OCA capture base, resolve the name as a JSON
+Pointer against `vcData` from the document root. If a pointer does not resolve,
+the processor MAY ignore that attribute or report an error.
+        </li>
+        <li>
+Apply overlays from the bundle (for example, label, information, format, and
+sensitive overlays) to produce presentation metadata for rendering `vcData`.
+The specifics of each overlay type are defined in [[[OCA]]].
+        </li>
+      </ol>
     </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -118,9 +118,12 @@
         alternateFormats: [ {uri: "diff-20111214.html", label: "diff to previous version"} ],
         */
         localBiblio: {
-          ENTRY: {
-            title: "Example Title",
-            href: "https://website.example/document",
+          OCA: {
+            title: "Overlays Capture Architecture Specification",
+            href: "https://oca.colossi.network/specification/",
+            authors: ["Human Colossus Foundation"],
+            status: "Living Specification",
+            date: "2024"
           },
         },
         lint: {"no-unused-dfns": false},
@@ -1355,9 +1358,9 @@ via `port` with the error message.
 
       <p>
         OCABundle is used by an issuer to specify rendering instructions
-        based on an Overlays Capture Architecture (OCA) Bundle. OCA provides a
-        standardized way to define schemas with semantic overlays that enable
-        multi-language support, data entry formats, sensitive data flagging, and
+        based on an Overlays Capture Architecture (OCA) Bundle as defined in [[[OCA]]].
+        OCA provides a standardized way to define schemas with semantic overlays that
+        enable multi-language support, data entry formats, sensitive data flagging, and
         rich metadata for rendering verifiable credentials in a consistent and
         interoperable manner.
       </p>

--- a/index.html
+++ b/index.html
@@ -297,9 +297,9 @@ The value of the `renderMethod` property MUST specify one or
 more rendering methods that can be used by software to express the
 [=verifiable credential=] using a visual, auditory, or haptic mechanism. Each
 `renderMethod` value MUST specify its `type`, for example,
-`TemplateRenderMethod`. The precise contents of each rendering
-hint is determined by the specific `renderMethod` `type`
-definition.
+`TemplateRenderMethod`, `OpenAttestationEmbeddedRenderer`, or `OCABundle`.
+The precise contents of each rendering hint is determined by the specific
+`renderMethod` `type` definition.
           </dd>
         </dl>
       </section>
@@ -1348,6 +1348,242 @@ via `port` with the error message.
                 </table>
             </section>
         </section>
+    </section>
+
+    <section>
+      <h4>OCABundle</h4>
+
+      <p>
+        OCABundle is used by an issuer to specify rendering instructions
+        based on an Overlays Capture Architecture (OCA) Bundle. OCA provides a
+        standardized way to define schemas with semantic overlays that enable
+        multi-language support, data entry formats, sensitive data flagging, and
+        rich metadata for rendering verifiable credentials in a consistent and
+        interoperable manner.
+      </p>
+
+      <p>
+        An OCA Bundle consists of a capture base that defines the core structure
+        and data types of the credential attributes, along with various overlays
+        that provide additional context such as labels, character encoding, format
+        specifications, entry codes, and information overlays. This layered approach
+        enables flexible and culturally-aware rendering of credentials while maintaining
+        data integrity.
+      </p>
+
+      <p>
+        When OCA is used as a render method for [=verifiable credentials=], the capture
+        base in the OCA Bundle uses JSON paths (as defined in [[[RFC6901]]]) as attribute
+        names to reference properties within the [=verifiable credential=]'s
+        `credentialSubject`, and defines the data type for each attribute. For example,
+        an attribute named `/degree/name` would reference the `name` property within
+        the nested `degree` object of the credential subject. The overlays then provide
+        presentation metadata such as human-readable labels in multiple languages,
+        formatting rules for dates and numbers, constraints for data entry, and
+        descriptive information about each attribute. This separation allows the same
+        credential data to be rendered differently based on context, locale, or user
+        preferences while maintaining a consistent semantic foundation.
+      </p>
+
+      <p>
+        When an [=issuer=] desires to specify OCA-based rendering instructions
+        for a [=verifiable credential=], they MAY add a `renderMethod` property
+        that uses the data model described below.
+      </p>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th style="white-space: nowrap">Property</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>id</td>
+            <td>
+A REQUIRED [=string=] that follows the [[[URL]]] specification and, when fetched,
+dereferences to an OCA Bundle in JSON format. The OCA Bundle contains the schema
+base and associated overlays needed for rendering the credential.
+            </td>
+          </tr>
+          <tr>
+            <td>type</td>
+            <td>
+A REQUIRED [=string=] that MUST be the value `OCABundle`.
+            </td>
+          </tr>
+          <tr>
+            <td>name</td>
+            <td>
+An OPTIONAL human-readable [=string=] that can be displayed to provide a hint to
+the type of rendering that will be performed. This property might be used in a
+graphical interface that enables an individual to select between multiple
+presentation modes.
+            </td>
+          </tr>
+          <tr>
+            <td>description</td>
+            <td>
+An OPTIONAL human-readable [=string=] that provides a more detailed description
+of the OCA-based rendering method and when it might be useful.
+            </td>
+          </tr>
+          <tr>
+            <td>digestMultibase</td>
+            <td>
+An OPTIONAL multibase-encoded Multihash of the OCA Bundle. The multibase
+value MUST be `u` (base64url-nopad) and the multihash value MUST be SHA-2 with
+256 bits of output (0x12 in the multicodec table). This property can be used by
+verifiers to ensure the integrity of the fetched OCA Bundle.
+            </td>
+          </tr>
+          <tr>
+            <td>version</td>
+            <td>
+An OPTIONAL [=string=] that specifies the OCA specification version that the
+referenced OCA Bundle conforms to (e.g., "v2.0.0-rc1", "v2.0.0", "v1.0").
+This property helps renderers determine compatibility and select appropriate
+processing logic for the OCA Bundle format.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        The data model shown above is expressed in a [=verifiable credential=] in
+        the example below.
+      </p>
+
+      <pre
+        class="example nohighlight"
+        title="Usage of OCABundle render method with a remote OCA Bundle"
+      >
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://example.org/oca/v1"
+  ],
+  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": {
+    "id": "https://example.edu/issuers/565049",
+    "name": "Example University"
+  },
+  "validFrom": "2024-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science and Arts",
+      "degreeType": "Undergraduate",
+      "major": "Computer Science"
+    }
+  },
+  <span class="highlight">"renderMethod": [{
+    "id": "https://example.edu/oca-bundles/degree-2024.json",
+    "type": "OCABundle",
+    "name": "University Degree Display",
+    "description": "Renders the degree credential with multi-language support",
+    "digestMultibase": "uEiC96D8xPcVfm...WNcMF4Kc-Yw",
+    "version": "v2.0.0-rc1"
+  }]</span>
+}
+      </pre>
+
+      <p>
+        In this example, the OCA Bundle located at
+        `https://example.edu/oca-bundles/degree-2024.json` contains the schema
+        base and overlays necessary to render the credential. The bundle might
+        include label overlays for multiple languages, format overlays for date
+        and number formatting, and information overlays with descriptions of each
+        attribute.
+      </p>
+
+      <p>
+        An example OCA Bundle structure for this credential might look like:
+      </p>
+
+      <pre
+        class="example nohighlight"
+        title="Example OCA Bundle structure with JSON path attributes"
+      >
+{
+  "bundle": {
+    "digest": "EBfdlu8R27Fbx-ehrqwIxQ-na4B7A4LqidzXqj8gkzHp",
+    "capture_base": {
+      "digest": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+      "type": "capture_base/2.0.0",
+      "attributes": {
+        "/degree/type": "Text",
+        "/degree/name": "Text",
+        "/degree/degreeType": "Text",
+        "/degree/major": "Text"
+      }
+    },
+    "overlays": {
+      "meta": {
+        "digest": "EMzAk6N2iI1K5EpS9YqU7WxTc8BvPq1RgFn0D4XyJwLz",
+        "type": "meta/2.0.0",
+        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+        "name": "University Degree Credential",
+        "description": "Academic degree credential issued by universities"
+      },
+      "label": [
+        {
+          "digest": "EJqWh3K9fF8H2BmP6VnR4TxQz5YsLm8NcDk7A1UvGtIw",
+          "type": "label/2.0.0",
+          "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+          "language": "en",
+          "attribute_labels": {
+            "/degree/type": "Degree Type",
+            "/degree/name": "Degree Name",
+            "/degree/degreeType": "Degree Classification",
+            "/degree/major": "Major"
+          }
+        },
+        {
+          "digest": "EKpXi4L0gG9I3CnQ7WoS5UyRa6ZtNo9OdEl8B2VwHuJx",
+          "type": "label/2.0.0",
+          "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+          "language": "fr",
+          "attribute_labels": {
+            "/degree/type": "Type de diplôme",
+            "/degree/name": "Nom du diplôme",
+            "/degree/degreeType": "Classification du diplôme",
+            "/degree/major": "Spécialisation"
+          }
+        }
+      ],
+      "information": {
+        "digest": "ELrYj5M1hH0J4DoR8XpT6VzSb7AuOp0QeFm9C3WxIvKy",
+        "type": "information/2.0.0",
+        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+        "language": "en",
+        "attribute_information": {
+          "/degree/type": "The type of academic degree awarded",
+          "/degree/name": "The full official name of the degree",
+          "/degree/degreeType": "Classification level (e.g., Undergraduate, Graduate)",
+          "/degree/major": "The primary field of study"
+        }
+      },
+      "sensitive": {
+        "digest": "ENaZl7O3jJ2L6FqT0ZrV8XyUd9CwRs2ShGo1E5YzKxMa",
+        "type": "sensitive/2.0.0",
+        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+        "attributes": [
+          "/degree/name"
+        ]
+      }
+    }
+  }
+}
+      </pre>
+
+      <p>
+        Implementers can use the OCA Bundle to generate appropriate user interfaces,
+        select language-specific labels, apply format specifications, and ensure
+        consistent rendering across different applications and platforms.
+      </p>
     </section>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -1035,8 +1035,9 @@ via `port` with the error message.
 OverlayRenderMethod is used by an [=issuer=] to link a [=verifiable credential=]
 to an external package of presentation metadata&mdash;such as an Overlays Capture
 Architecture (OCA) Bundle [[[OCA]]]&mdash;without prescribing a single visual
-template. A capture base describes credential attributes (often as JSON Pointer
-[[RFC6901]] paths from the document root), and overlays supply labels, formats,
+template. A capture base describes credential attributes as JSON Pointer
+[[RFC6901]] paths from the root of the [=verifiable credential=] document, and
+overlays supply labels, formats,
 sensitive-data flags, and related presentation rules. Renderers use this
 information to build user interfaces, select locales, and display fields
 consistently across applications.
@@ -1214,7 +1215,8 @@ either as a URL or as a map with an `id` that dereferences to the bundle.
           <p>
 When processing this render suite, attribute names in the capture base MUST be
 interpreted as JSON Pointer paths [[RFC6901]] from the root of the
-[=verifiable credential=] document unless otherwise specified by [[[OCA]]].
+[=verifiable credential=] document. Attribute names in overlays that reference
+capture base attributes MUST use the same JSON Pointer paths.
 For example, an attribute named `/credentialSubject/degree/name` references
 the `name` property within the `degree` object of `credentialSubject`. Overlays
 in the bundle provide presentation metadata such as human-readable labels in

--- a/index.html
+++ b/index.html
@@ -1406,7 +1406,7 @@ via `port` with the error message.
             <td>id</td>
             <td>
 A REQUIRED [=string=] that follows the [[[URL]]] specification and, when fetched,
-dereferences to an OCA Bundle in JSON format. The OCA Bundle contains the schema
+dereferences to an OCA Bundle in JSON format. The OCA Bundle contains the capture
 base and associated overlays needed for rendering the credential.
             </td>
           </tr>
@@ -1495,7 +1495,7 @@ processing logic for the OCA Bundle format.
 
       <p>
         In this example, the OCA Bundle located at
-        `https://example.edu/oca-bundles/degree-2024.json` contains the schema
+        `https://example.edu/oca-bundles/degree-2024.json` contains the capture
         base and overlays necessary to render the credential. The bundle might
         include label overlays for multiple languages, format overlays for date
         and number formatting, and information overlays with descriptions of each

--- a/index.html
+++ b/index.html
@@ -1462,7 +1462,7 @@ processing logic for the OCA Bundle format.
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://example.org/oca/v1"
+    "https://www.w3.org/ns/credentials/examples/v2"
   ],
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": {

--- a/index.html
+++ b/index.html
@@ -1509,54 +1509,54 @@ processing logic for the OCA Bundle format.
       >
 {
   "bundle": {
+    "v": "OCAS11JSON000646_",
     "digest": "EBfdlu8R27Fbx-ehrqwIxQ-na4B7A4LqidzXqj8gkzHp",
     "capture_base": {
       "digest": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
-      "type": "capture_base/2.0.0",
+      "type": "spec/capture_base/2.0.0",
       "attributes": {
         "/degree/type": "Text",
         "/degree/name": "Text",
         "/degree/degreeType": "Text",
         "/degree/major": "Text"
-      }
+      },
+      "classification": ""
     },
-    "overlays": {
-      "meta": {
+    "overlays": [
+      {
         "digest": "EMzAk6N2iI1K5EpS9YqU7WxTc8BvPq1RgFn0D4XyJwLz",
-        "type": "meta/2.0.0",
+        "type": "spec/overlays/meta/2.0.0",
         "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
         "name": "University Degree Credential",
         "description": "Academic degree credential issued by universities"
       },
-      "label": [
-        {
-          "digest": "EJqWh3K9fF8H2BmP6VnR4TxQz5YsLm8NcDk7A1UvGtIw",
-          "type": "label/2.0.0",
-          "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
-          "language": "en",
-          "attribute_labels": {
-            "/degree/type": "Degree Type",
-            "/degree/name": "Degree Name",
-            "/degree/degreeType": "Degree Classification",
-            "/degree/major": "Major"
-          }
-        },
-        {
-          "digest": "EKpXi4L0gG9I3CnQ7WoS5UyRa6ZtNo9OdEl8B2VwHuJx",
-          "type": "label/2.0.0",
-          "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
-          "language": "fr",
-          "attribute_labels": {
-            "/degree/type": "Type de diplôme",
-            "/degree/name": "Nom du diplôme",
-            "/degree/degreeType": "Classification du diplôme",
-            "/degree/major": "Spécialisation"
-          }
+      {
+        "digest": "EJqWh3K9fF8H2BmP6VnR4TxQz5YsLm8NcDk7A1UvGtIw",
+        "type": "spec/overlays/label/2.0.0",
+        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+        "language": "en",
+        "attribute_labels": {
+          "/degree/type": "Degree Type",
+          "/degree/name": "Degree Name",
+          "/degree/degreeType": "Degree Classification",
+          "/degree/major": "Major"
         }
-      ],
-      "information": {
+      },
+      {
+        "digest": "EKpXi4L0gG9I3CnQ7WoS5UyRa6ZtNo9OdEl8B2VwHuJx",
+        "type": "spec/overlays/label/2.0.0",
+        "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
+        "language": "fr",
+        "attribute_labels": {
+          "/degree/type": "Type de diplôme",
+          "/degree/name": "Nom du diplôme",
+          "/degree/degreeType": "Classification du diplôme",
+          "/degree/major": "Spécialisation"
+        }
+      },
+      {
         "digest": "ELrYj5M1hH0J4DoR8XpT6VzSb7AuOp0QeFm9C3WxIvKy",
-        "type": "information/2.0.0",
+        "type": "spec/overlays/information/2.0.0",
         "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
         "language": "en",
         "attribute_information": {
@@ -1566,15 +1566,15 @@ processing logic for the OCA Bundle format.
           "/degree/major": "The primary field of study"
         }
       },
-      "sensitive": {
+      {
         "digest": "ENaZl7O3jJ2L6FqT0ZrV8XyUd9CwRs2ShGo1E5YzKxMa",
-        "type": "sensitive/2.0.0",
+        "type": "spec/overlays/sensitive/2.0.0",
         "capture_base": "ECui6bAv2zzW2gMVQbKT3M7g2q4r6yWKf2Y2k9CDa8Nq",
         "attributes": [
           "/degree/name"
         ]
       }
-    }
+    ]
   }
 }
       </pre>

--- a/index.html
+++ b/index.html
@@ -1075,7 +1075,8 @@ A REQUIRED [=string=] that MUST be the value `OverlayRenderMethod`.
               <td>renderSuite</td>
               <td>
 A REQUIRED [=string=] that identifies the overlay package format and processing
-algorithm. The `oca-bundle-v2` render suite is defined in this specification.
+algorithm. The `oca-bundle-v2` render suite (OCA v2.0.0) is defined in this
+specification.
               </td>
             </tr>
             <tr>
@@ -1206,10 +1207,12 @@ example below.
           <h3>The `oca-bundle-v2` Render Suite</h3>
 
           <p>
-The `oca-bundle-v2` render suite uses an OCA Bundle as defined in [[[OCA]]].
-The bundle contains a capture base and overlays. For this render suite,
-`renderSuite` MUST be the value `oca-bundle-v2`, and `bundle` MUST be present
-either as a URL or as a map with an `id` that dereferences to the bundle.
+The `oca-bundle-v2` render suite refers to the Overlays Capture Architecture
+(OCA) <a href="https://oca.colossi.network/specification/">v2.0.0</a>
+specification [[[OCA]]]. It uses an OCA Bundle containing a capture base and
+overlays. For this render suite, `renderSuite` MUST be the value
+`oca-bundle-v2`, and `bundle` MUST be present either as a URL or as a map with
+an `id` that dereferences to the bundle.
           </p>
 
           <p>


### PR DESCRIPTION
References #15

## Summary

Adds **OverlayRenderMethod** as a sibling to `TemplateRenderMethod` for linking a verifiable credential to an external overlay package (OCA Bundle) without prescribing a single visual template.

- **`renderSuite: oca-bundle-v2`** — OCA major version is inferred from the suite name (no separate `version` property)
- **`bundle`** — URL or map (`id`, `mediaType`, `digestMultibase`) pointing at the OCA bundle
- Shared shape with template methods: `name`, `description`, `renderProperty`, optional top-level `id` / `digestMultibase`
- JSON Pointer paths from VC document root in capture base attributes (RFC 6901)
- **`Render (OverlayRenderMethod)`** processing algorithm for `oca-bundle-v2`
- OCA bibliography entry and examples (VC + bundle structure)
- Rebased on current `main` (includes HTML render suite, EmbeddedRenderer)

Supersedes the earlier `OCABundle` type proposed in this PR.

## Test plan

- [ ] ReSpec preview builds without errors
- [ ] WG review: naming (`OverlayRenderMethod` vs alternatives), `bundle` REQUIRED semantics
- [ ] Align with any follow-up PR for common `renderMethod` properties


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OpSecId/vc-render-method/pull/30.html" title="Last updated on May 19, 2026, 2:40 PM UTC (6b3add1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-render-method/30/bbcb388...OpSecId:6b3add1.html" title="Last updated on May 19, 2026, 2:40 PM UTC (6b3add1)">Diff</a>