### PR TITLE
Add missing w3cid

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
           url: "https://www.linkedin.com/in/patrick-stlouis/",
           company: "Open Security and Identity",
           companyURL: "https://opsecid.ca/",
-          w3cid: 1000000
+          w3cid: 162334
         }, {
           name: "Hendry POH",
           url: "https://www.linkedin.com/in/hendrypoh/",
@@ -97,7 +97,8 @@
           name: "Patrick St. Louis",
           url: "https://www.linkedin.com/in/patrick-stlouis/",
           company: "Open Security and Identity",
-          companyURL: "https://opsecid.ca/"
+          companyURL: "https://opsecid.ca/",
+          w3cid: 162334
         }],
 
         github: "https://github.com/w3c/vc-render-method/",


### PR DESCRIPTION
Here's my w3cid


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OpSecId/vc-render-method/pull/31.html" title="Last updated on Oct 26, 2025, 9:24 PM UTC (8de7978)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-render-method/31/2f75639...OpSecId:8de7978.html" title="Last updated on Oct 26, 2025, 9:24 PM UTC (8de7978)">Diff</a>