### PR TITLE
Render method to enable card-like displays in wallets and displayers

### DIFF
--- a/index.html
+++ b/index.html
@@ -603,23 +603,221 @@ using the `digestMultibase` property:
         <section>
           <h3>The `json-card` Render Suite</h3>
           <p>
-The `json-card` render suite uses the JSONata templating language to
-transform a [=verifiable credential=] into a standardized JSON card format.
-This format enables wallets to display credentials in a responsive card layout
-with key data highlighted and configurable additional fields. Wallets that
-implement this method can render the standardized JSON output into their own
-card UI designs, allowing credentials to be displayed even when a wallet
-doesn't natively support a specific credential type.
+The `json-card` render suite uses JSON templates to transform a
+[=verifiable credential=] into a standardized JSON card format. This format
+enables wallets to display credentials in a responsive card layout with key
+data highlighted and configurable additional fields. Wallets that implement
+this method can render the standardized JSON output into their own card UI
+designs, allowing credentials to be displayed even when a wallet doesn't
+natively support a specific credential type.
           </p>
 
           <p>
-The template is expressed as a JSONata expression string. When the template
-is evaluated against the [=verifiable credential=] data, it MUST produce
-output that conforms to the json-card JSON schema defined below.
+The template is a JSON object that matches the json-card output structure.
+String values in the template can be JSON pointer strings (as specified in
+[[[RFC6901]]]) that reference fields in the [=verifiable credential=]. When
+processing the template, JSON pointer strings are evaluated against the
+credential data and replaced with the resolved values. The template MUST
+conform to the JSON template schema defined below, and the resulting output
+MUST conform to the json-card output schema. Compound data across multiple
+fields is not supported; each field references a single JSON pointer.
           </p>
 
           <section>
-            <h4>JSON Card Schema</h4>
+            <h4>JSON Template Schema</h4>
+            <p>
+The template for a `json-card` render suite MUST be a JSON object that
+conforms to the following structure. The template structure matches the
+output structure, but string values can be either literal strings or JSON
+pointer strings (starting with `/`) that reference fields in the
+[=verifiable credential=]. The template SHOULD be validated against this
+schema before processing.
+            </p>
+
+            <table class="simple">
+              <thead>
+                <tr>
+                  <th style="white-space: nowrap">Property</th>
+                  <th>Type</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>name</td>
+                  <td>[=string=]</td>
+                  <td>
+A REQUIRED string that is either a literal display name or a JSON pointer
+string (e.g., <code>"/credentialSubject/degree/name"</code>) that references
+the credential data.
+                  </td>
+                </tr>
+                <tr>
+                  <td>description</td>
+                  <td>[=string=]</td>
+                  <td>
+A REQUIRED string that is either a literal description or a JSON pointer
+string that references the credential data.
+                  </td>
+                </tr>
+                <tr>
+                  <td>icon</td>
+                  <td>[=string=]</td>
+                  <td>
+An OPTIONAL string that is either a literal URL/data URI or a JSON pointer
+string that references the credential data.
+                  </td>
+                </tr>
+                <tr>
+                  <td>theme</td>
+                  <td>[=ordered map|map=]</td>
+                  <td>
+An OPTIONAL color theme object with the following properties:
+                    <ul>
+                      <li><code>primaryColor</code> ([=string=]): Primary color as a literal string or JSON pointer</li>
+                      <li><code>accentColor</code> ([=string=]): Accent color as a literal string or JSON pointer</li>
+                    </ul>
+                  </td>
+                </tr>
+                <tr>
+                  <td>fields</td>
+                  <td>[=list=]</td>
+                  <td>
+A REQUIRED ordered list of custom data fields. Each field is an object with:
+                    <ul>
+                      <li><code>label</code> ([=string=]): The field label (MUST be a literal string, not a JSON pointer)</li>
+                      <li><code>value</code> ([=string=]): The field value as a JSON pointer string (e.g., <code>"/issuer"</code>)</li>
+                    </ul>
+                  </td>
+                </tr>
+                <tr>
+                  <td>issueDate</td>
+                  <td>[=string=]</td>
+                  <td>
+An OPTIONAL string that is either a literal ISO 8601 date or a JSON pointer
+string that references the credential data.
+                  </td>
+                </tr>
+                <tr>
+                  <td>expirationDate</td>
+                  <td>[=string=]</td>
+                  <td>
+An OPTIONAL string that is either a literal ISO 8601 date or a JSON pointer
+string that references the credential data.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <p>
+The following JSON Schema implements the template structure rules defined
+above:
+            </p>
+
+            <pre class="example nohighlight"
+                 title="JSON Schema for json-card template">
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["name", "description", "fields"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Display name as a literal string or JSON pointer (e.g., \"/credentialSubject/degree/name\")"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description as a literal string or JSON pointer"
+    },
+    "icon": {
+      "type": "string",
+      "description": "Icon URL/data URI as a literal string or JSON pointer"
+    },
+    "theme": {
+      "type": "object",
+      "properties": {
+        "primaryColor": {
+          "type": "string",
+          "description": "Primary color as a literal string or JSON pointer"
+        },
+        "accentColor": {
+          "type": "string",
+          "description": "Accent color as a literal string or JSON pointer"
+        }
+      },
+      "additionalProperties": false
+    },
+    "fields": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["label", "value"],
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Field label (MUST be a literal string, not a JSON pointer)"
+          },
+          "value": {
+            "type": "string",
+            "pattern": "^/",
+            "description": "Field value as a JSON pointer string (MUST start with \"/\")"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "issueDate": {
+      "type": "string",
+      "description": "Issue date as a literal ISO 8601 date string or JSON pointer"
+    },
+    "expirationDate": {
+      "type": "string",
+      "description": "Expiration date as a literal ISO 8601 date string or JSON pointer"
+    }
+  },
+  "additionalProperties": false
+}
+            </pre>
+
+            <p>
+The following example shows a valid json-card template with JSON pointer
+strings:
+            </p>
+
+            <pre class="example nohighlight"
+                 title="Example json-card template">
+{
+  "name": "/credentialSubject/degree/name",
+  "description": "University Degree Credential",
+  "icon": "/credentialSubject/icon",
+  "theme": {
+    "primaryColor": "#1a5490",
+    "accentColor": "/credentialSubject/theme/accentColor"
+  },
+  "fields": [
+    {
+      "label": "Institution",
+      "value": "/issuer"
+    },
+    {
+      "label": "Degree Type",
+      "value": "/credentialSubject/degree/type"
+    },
+    {
+      "label": "Issue Date",
+      "value": "/validFrom"
+    }
+  ],
+  "issueDate": "/validFrom",
+  "expirationDate": "/validUntil"
+}
+            </pre>
+
+          </section>
+
+          <section>
+            <h4>JSON Card Output Schema</h4>
             <p>
 The output of a `json-card` template MUST be a JSON object that conforms to
 the following structure:
@@ -729,9 +927,60 @@ The following example shows a valid json-card output:
 
           </section>
 
+          <section>
+            <h4>Template Processing</h4>
+            <p>
+When processing a `json-card` template, the following steps MUST be
+performed:
+            </p>
+
+            <ol class="algorithm">
+              <li>
+Validate the template JSON object against the JSON template schema defined
+above. If validation fails, processing MUST stop and an error MUST be
+returned.
+              </li>
+              <li>
+For each string value in the template object:
+                <ol class="algorithm">
+                  <li>
+If the string value starts with `/` (indicating it is a JSON pointer),
+evaluate it using the JSON Pointer algorithm [[[RFC6901]]] against the
+[=verifiable credential=] as the target document.
+                  </li>
+                  <li>
+If the JSON pointer evaluation succeeds, replace the JSON pointer string with
+the resolved value. If the resolved value is not a string, convert it to a
+string representation.
+                  </li>
+                  <li>
+If the JSON pointer evaluation fails or returns `null`, the behavior is
+implementation-specific. Implementations MAY use an empty string, leave the
+value as `null`, or signal an error.
+                  </li>
+                  <li>
+If the string value does not start with `/`, treat it as a literal string
+and leave it unchanged.
+                  </li>
+                </ol>
+              </li>
+              <li>
+Validate the resulting JSON object against the json-card output schema. If
+validation fails, processing MUST stop and an error MUST be returned.
+              </li>
+            </ol>
+
+            <p>
+Note that compound data across multiple fields is not supported. Each field
+in the template references a single JSON pointer that resolves to a single
+value from the credential.
+            </p>
+
+          </section>
+
           <p>
-In the example below, a fully embedded JSONata template is used as the rendering
-template.
+In the example below, a fully embedded JSON template is used as the rendering
+template. The template uses JSON pointer strings to reference credential data.
           </p>
 
           <pre class="example nohighlight"
@@ -741,26 +990,28 @@ template.
   "renderMethod": {
     "type": "TemplateRenderMethod",
     "renderSuite": "json-card",
-    "template": "data:text/plain;base64,eyJuYW1lIjogY3JlZGVudGlhbFN1YmplY3QuZGVncmVlLm5hbWUsICJkZXNjcmlwdGlvbiI6ICJVbml2ZXJzaXR5IERlZ3JlZSBDcmVkZW50aWFsIiwgImZpZWxkcyI6IFt7ImxhYmVsIjogIkluc3RpdHV0aW9uIiwgInZhbHVlIjogaXNzdWVyfV19"
+    <span class="comment">// the JSON template is embedded in the VC</span>
+    "template": "data:application/json;base64,eyJuYW1lIjogIi9jcmVkZW50aWFsU3ViamVjdC9kZWdyZWUvbmFtZSIsICJkZXNjcmlwdGlvbiI6ICJVbml2ZXJzaXR5IERlZ3JlZSBDcmVkZW50aWFsIiwgImZpZWxkcyI6IFt7ImxhYmVsIjogIkluc3RpdHV0aW9uIiwgInZhbHVlIjogIi9pc3N1ZXIifV19"
   }
 }
           </pre>
 
           <p>
-The next example links to the JSONata template on the Web and secures it against
+The next example links to the JSON template on the Web and secures it against
 modification by using the `digestMultibase` property.
           </p>
 
           <pre class="example nohighlight"
-              title="A remotely hosted JSONata template for a json-card render template">
+              title="A remotely hosted JSON template for a json-card render template">
 {
 <span class="comment">...</span>
 "renderMethod": {
   "type": "TemplateRenderMethod",
   "renderSuite": "json-card",
   "template": {
-    "id": "https://degree.example/credential-templates/bachelors.jsonata",
-    "mediaType": "text/plain",
+    <span class="comment">// this JSON template is fetched from the Web</span>
+    "id": "https://degree.example/credential-templates/bachelors.json",
+    "mediaType": "application/json",
     "digestMultibase": "zQmerWC85Wg6wFl9znFCwYxApG270iEu5h6JqWAPdhyxz2dR"
   }
 }

--- a/index.html
+++ b/index.html
@@ -607,19 +607,19 @@ The `json-card` render suite uses JSON templates to transform a
 [=verifiable credential=] into a standardized JSON card format. This format
 enables wallets to display credentials in a responsive card layout with key
 data highlighted and configurable additional fields. Wallets that implement
-this method can render the standardized JSON output into their own card UI
+this method can render the standardized JSON output in their own card UI
 designs, allowing credentials to be displayed even when a wallet doesn't
 natively support a specific credential type.
           </p>
 
           <p>
-The template is a JSON object that matches the json-card output structure.
+The template is a JSON object that matches the `json-card` output structure.
 String values in the template can be JSON pointer strings (as specified in
 [[[RFC6901]]]) that reference fields in the [=verifiable credential=]. When
 processing the template, JSON pointer strings are evaluated against the
 credential data and replaced with the resolved values. The template MUST
 conform to the JSON template schema defined below, and the resulting output
-MUST conform to the json-card output schema. Compound data across multiple
+MUST conform to the `json-card` output schema. Compound data across multiple
 fields is not supported; each field references a single JSON pointer.
           </p>
 
@@ -781,7 +781,7 @@ above:
             </pre>
 
             <p>
-The following example shows a valid json-card template with JSON pointer
+The following example shows a valid `json-card` template with JSON pointer
 strings:
             </p>
 
@@ -893,7 +893,7 @@ An OPTIONAL ISO 8601 date string indicating when the credential expires.
             </table>
 
             <p>
-The following example shows a valid json-card output:
+The following example shows a valid `json-card` output:
             </p>
 
             <pre class="example nohighlight"
@@ -965,7 +965,7 @@ and leave it unchanged.
                 </ol>
               </li>
               <li>
-Validate the resulting JSON object against the json-card output schema. If
+Validate the resulting JSON object against the `json-card` output schema. If
 validation fails, processing MUST stop and an error MUST be returned.
               </li>
             </ol>

--- a/index.html
+++ b/index.html
@@ -118,6 +118,11 @@
         alternateFormats: [ {uri: "diff-20111214.html", label: "diff to previous version"} ],
         */
         localBiblio: {
+          BCP47: {
+            title: "Tags for Identifying Languages",
+            href: "https://www.rfc-editor.org/info/bcp47",
+            publisher: "IETF",
+          },
           ENTRY: {
             title: "Example Title",
             href: "https://website.example/document",
@@ -687,23 +692,24 @@ A REQUIRED ordered list of custom data fields. Each field is an object with:
                     <ul>
                       <li><code>label</code> ([=string=]): The field label (MUST be a literal string, not a JSON pointer)</li>
                       <li><code>value</code> ([=string=]): The field value as a JSON pointer string (e.g., <code>"/issuer"</code>)</li>
+                      <li><code>language</code> ([=string=]): An OPTIONAL language tag (as specified in [[[BCP47]]]) indicating the language of the field's label and/or value</li>
                     </ul>
                   </td>
                 </tr>
                 <tr>
-                  <td>issueDate</td>
+                  <td>validFrom</td>
                   <td>[=string=]</td>
                   <td>
 An OPTIONAL string that is either a literal ISO 8601 date or a JSON pointer
-string that references the credential data.
+string that references the credential data (validity start date).
                   </td>
                 </tr>
                 <tr>
-                  <td>expirationDate</td>
+                  <td>validUntil</td>
                   <td>[=string=]</td>
                   <td>
 An OPTIONAL string that is either a literal ISO 8601 date or a JSON pointer
-string that references the credential data.
+string that references the credential data (validity end date).
                   </td>
                 </tr>
               </tbody>
@@ -762,18 +768,22 @@ above:
             "type": "string",
             "pattern": "^/",
             "description": "Field value as a JSON pointer string (MUST start with \"/\")"
+          },
+          "language": {
+            "type": "string",
+            "description": "Optional BCP 47 language tag for the field"
           }
         },
         "additionalProperties": false
       }
     },
-    "issueDate": {
+    "validFrom": {
       "type": "string",
-      "description": "Issue date as a literal ISO 8601 date string or JSON pointer"
+      "description": "Validity start date as a literal ISO 8601 date string or JSON pointer"
     },
-    "expirationDate": {
+    "validUntil": {
       "type": "string",
-      "description": "Expiration date as a literal ISO 8601 date string or JSON pointer"
+      "description": "Validity end date as a literal ISO 8601 date string or JSON pointer"
     }
   },
   "additionalProperties": false
@@ -809,8 +819,8 @@ strings:
       "value": "/validFrom"
     }
   ],
-  "issueDate": "/validFrom",
-  "expirationDate": "/validUntil"
+  "validFrom": "/validFrom",
+  "validUntil": "/validUntil"
 }
             </pre>
 
@@ -872,21 +882,22 @@ A REQUIRED ordered list of custom data fields. Each field is an object with:
                     <ul>
                       <li><code>label</code> ([=string=]): The field label</li>
                       <li><code>value</code> ([=string=]): The field value</li>
+                      <li><code>language</code> ([=string=]): An OPTIONAL language tag (as specified in [[[BCP47]]]) indicating the language of the field</li>
                     </ul>
                   </td>
                 </tr>
                 <tr>
-                  <td>issueDate</td>
+                  <td>validFrom</td>
                   <td>[=string=]</td>
                   <td>
-An OPTIONAL ISO 8601 date string indicating when the credential was issued.
+An OPTIONAL ISO 8601 date string indicating when the credential becomes valid.
                   </td>
                 </tr>
                 <tr>
-                  <td>expirationDate</td>
+                  <td>validUntil</td>
                   <td>[=string=]</td>
                   <td>
-An OPTIONAL ISO 8601 date string indicating when the credential expires.
+An OPTIONAL ISO 8601 date string indicating when the credential ceases to be valid.
                   </td>
                 </tr>
               </tbody>
@@ -920,8 +931,8 @@ The following example shows a valid `json-card` output:
       "value": "2010-05-15"
     }
   ],
-  "issueDate": "2010-01-01T19:23:24Z",
-  "expirationDate": null
+  "validFrom": "2010-01-01T19:23:24Z",
+  "validUntil": null
 }
             </pre>
 

--- a/index.html
+++ b/index.html
@@ -601,6 +601,193 @@ using the `digestMultibase` property:
         </section>
 
         <section>
+          <h3>The `json-card` Render Suite</h3>
+          <p>
+The `json-card` render suite uses the JSONata templating language to
+transform a [=verifiable credential=] into a standardized JSON card format.
+This format enables wallets to display credentials in a responsive card layout
+with key data highlighted and configurable additional fields. Wallets that
+implement this method can render the standardized JSON output into their own
+card UI designs, allowing credentials to be displayed even when a wallet
+doesn't natively support a specific credential type.
+          </p>
+
+          <p>
+The template is expressed as a JSONata expression string. When the template
+is evaluated against the [=verifiable credential=] data, it MUST produce
+output that conforms to the json-card JSON schema defined below.
+          </p>
+
+          <section>
+            <h4>JSON Card Schema</h4>
+            <p>
+The output of a `json-card` template MUST be a JSON object that conforms to
+the following structure:
+            </p>
+
+            <table class="simple">
+              <thead>
+                <tr>
+                  <th style="white-space: nowrap">Property</th>
+                  <th>Type</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>name</td>
+                  <td>[=string=]</td>
+                  <td>
+A REQUIRED display name for the credential card.
+                  </td>
+                </tr>
+                <tr>
+                  <td>description</td>
+                  <td>[=string=]</td>
+                  <td>
+A REQUIRED description text for the credential card.
+                  </td>
+                </tr>
+                <tr>
+                  <td>icon</td>
+                  <td>[=string=]</td>
+                  <td>
+An OPTIONAL URL or data URI for an icon or image to display on the card.
+                  </td>
+                </tr>
+                <tr>
+                  <td>theme</td>
+                  <td>[=ordered map|map=]</td>
+                  <td>
+An OPTIONAL color theme object with the following properties:
+                    <ul>
+                      <li><code>primaryColor</code> ([=string=]): Primary color for backgrounds and highlights</li>
+                      <li><code>accentColor</code> ([=string=]): Accent color for highlights and emphasis</li>
+                    </ul>
+                  </td>
+                </tr>
+                <tr>
+                  <td>fields</td>
+                  <td>[=list=]</td>
+                  <td>
+A REQUIRED ordered list of custom data fields. Each field is an object with:
+                    <ul>
+                      <li><code>label</code> ([=string=]): The field label</li>
+                      <li><code>value</code> ([=string=]): The field value</li>
+                    </ul>
+                  </td>
+                </tr>
+                <tr>
+                  <td>issueDate</td>
+                  <td>[=string=]</td>
+                  <td>
+An OPTIONAL ISO 8601 date string indicating when the credential was issued.
+                  </td>
+                </tr>
+                <tr>
+                  <td>expirationDate</td>
+                  <td>[=string=]</td>
+                  <td>
+An OPTIONAL ISO 8601 date string indicating when the credential expires.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <p>
+The following example shows a valid json-card output:
+            </p>
+
+            <pre class="example nohighlight"
+                 title="Example json-card output">
+{
+  "name": "Bachelor of Science and Arts",
+  "description": "University Degree Credential",
+  "icon": "https://example.edu/icons/degree.svg",
+  "theme": {
+    "primaryColor": "#1a5490",
+    "accentColor": "#4a90e2"
+  },
+  "fields": [
+    {
+      "label": "Institution",
+      "value": "Example University"
+    },
+    {
+      "label": "Degree Type",
+      "value": "BachelorDegree"
+    },
+    {
+      "label": "Graduation Date",
+      "value": "2010-05-15"
+    }
+  ],
+  "issueDate": "2010-01-01T19:23:24Z",
+  "expirationDate": null
+}
+            </pre>
+
+          </section>
+
+          <p>
+In the example below, a fully embedded JSONata template is used as the rendering
+template.
+          </p>
+
+          <pre class="example nohighlight"
+               title="Basic usage of the json-card render suite">
+{
+  <span class="comment">...</span>
+  "renderMethod": {
+    "type": "TemplateRenderMethod",
+    "renderSuite": "json-card",
+    "template": "data:text/plain;base64,eyJuYW1lIjogY3JlZGVudGlhbFN1YmplY3QuZGVncmVlLm5hbWUsICJkZXNjcmlwdGlvbiI6ICJVbml2ZXJzaXR5IERlZ3JlZSBDcmVkZW50aWFsIiwgImZpZWxkcyI6IFt7ImxhYmVsIjogIkluc3RpdHV0aW9uIiwgInZhbHVlIjogaXNzdWVyfV19"
+  }
+}
+          </pre>
+
+          <p>
+The next example links to the JSONata template on the Web and secures it against
+modification by using the `digestMultibase` property.
+          </p>
+
+          <pre class="example nohighlight"
+              title="A remotely hosted JSONata template for a json-card render template">
+{
+<span class="comment">...</span>
+"renderMethod": {
+  "type": "TemplateRenderMethod",
+  "renderSuite": "json-card",
+  "template": {
+    "id": "https://degree.example/credential-templates/bachelors.jsonata",
+    "mediaType": "text/plain",
+    "digestMultibase": "zQmerWC85Wg6wFl9znFCwYxApG270iEu5h6JqWAPdhyxz2dR"
+  }
+}
+          </pre>
+
+          <p>
+The next example links to the rendering template on the Web and secures it
+using the `digestMultibase` property:
+          </p>
+
+          <pre class="example nohighlight"
+              title="A remotely hosted json-card render method">
+{
+<span class="comment">...</span>
+"renderMethod": {
+  <span class="comment">// this render method is fetched from the Web</span>
+  "id": "https://degrees.example/bachelors-json-card.jsonld",
+  "mediaType": "application/ld+json",
+  "type": "TemplateRenderMethod",
+  "renderSuite": "json-card",
+  "digestMultibase": "zQmG270iEu5h6JqWAPdhyxz2dRerWC85Wg6wFl9znFCwYxAp"
+}
+          </pre>
+
+        </section>
+
+        <section>
           <h3>The `nfc` Render Suite</h3>
           <p>
 The `nfc` render suite transmits a binary payload representing the


### PR DESCRIPTION
For discussion and consideration, I don't have any particular product that aims to use this concept imminently.  Feel free to edit.

The concept is:
* If a credential uses this render method, it is possible to identify which data in the credential best corresponds to summary properties that would be desirable to display on a card, with a few top-level properties and a priority-ordered list of labeled data fields pulled out of a credential's structure for display.
* Summary views could display the core data fields plus one or two of the deeper `fields`, and detail views could display all of the `fields`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ottonomy/vc-render-method/pull/39.html" title="Last updated on Jul 28, 2026, 3:07 PM UTC (32a8bf5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-render-method/39/9a84189...ottonomy:32a8bf5.html" title="Last updated on Jul 28, 2026, 3:07 PM UTC (32a8bf5)">Diff</a>