### PR TITLE
Refer to mustache templating algorithm instead of reproducing a partial

### DIFF
--- a/index.html
+++ b/index.html
@@ -979,8 +979,10 @@ for rendering methods.
       <h5>Render (TemplateRenderMethod)</h5>
 
       <p>
-      The <a href="https://mustache.github.io/">Mustache</a> templating language is used render the [=verifiable credential=] into a visual representation.
-      See <a href="https://mustache.github.io/mustache.5.html">Mustache 5.0 Specification</a> for details.
+The <a href="https://mustache.github.io/">Mustache</a> templating language is used
+to produce a visual representation of the [=verifiable credential=].
+See the <a href="https://mustache.github.io/mustache.5.html">Mustache 5.0
+Specification</a> for details.
       </p>
     </section>
 


### PR DESCRIPTION
This PR adresses and fixes https://github.com/w3c/vc-render-method/issues/40 in a minimal way.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/european-epc-competence-center/vc-render-method/pull/41.html" title="Last updated on Jan 5, 2026, 10:42 AM UTC (25974a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-render-method/41/f1de044...european-epc-competence-center:25974a0.html" title="Last updated on Jan 5, 2026, 10:42 AM UTC (25974a0)">Diff</a>