### PR TITLE
Add devcontainer.json for preview in codespaces.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "extensions": ["ritwickdey.LiveServer"],
+  "forwardPorts": [5500],
+  "portsAttributes": {
+    "5500": {
+      "label": "Live Server"
+    }
+  }
+}


### PR DESCRIPTION
This eases the use of GitHub Codespaces for editing by providing a Live Server to preview the HTML while editing in a browser.

This is somewhat experimental, but it _may_ be useful for folks wanting to edit the HTML without downloading and installing all the necessary editing and previewing kit.

#### Usage
1. Click "Code" (top-right corner on this PR) and click "Create"
2. In the VS Code editor that opens in your browser, choose the `index.html` file.
3. Then click "Go Live" in the bottom right and a new tab should open with a live reloading preview of `index.html`.
4. In the editor tab, make changes to `index.html`.
5. In the preview tab, see the changes.

Pretty handy. 😎 

#### Stopping the Codespace

The containers are auto-stopped 30 minutes after inactivity, so if you want it stopped sooner, click the container name in the bottom right corner of the editor then click "Stop Container" in the list of options that appears. Or, click "Delete Container" if you're completely done with it.