### PR TITLE
Remove pdf-mustache render suite and svg-mustache render suite.

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,253 +471,118 @@ information from the [=verifiable credential=] listed in `renderProperty`.
         </p>
 
         <section>
-          <h3>The `svg-mustache` Render Suite</h3>
-          <p>
-The `svg-mustache` render suite uses the Mustache templating language to
-modify an SVG file, which is then used to render a visual representation
-of the [=verifiable credential=].
-          </p>
-
-          <p>
-In the example below, a fully embedded SVG file is used as the rendering
-template.
-          </p>
-
-          <pre class="example nohighlight"
-               title="Basic usage of the svg-mustache render suite">
-{
-  <span class="comment">...</span>
-  "renderMethod": {
-    "type": "TemplateRenderMethod",
-    "renderSuite": "svg-mustache",
-    <span class="comment">// the SVG file is embedded in the VC</span>
-    "template": "data:image/svg+xml;base64,Qjei89...3jZpW"
-  }
-}
-          </pre>
-
-          <p>
-The next example links to the SVG file on the Web and secures it against
-modification by using the `digestMultibase` property.
-          </p>
-
-          <pre class="example nohighlight"
-              title="A remotely hosted SVG file for an SVG render template">
-{
-<span class="comment">...</span>
-"renderMethod": {
-  "type": "TemplateRenderMethod",
-  "renderSuite": "svg-mustache",
-  "template": {
-    <span class="comment">// this SVG file is fetched from the Web</span>
-    "id": "https://degree.example/credential-templates/bachelors",
-    "mediaType": "image/svg+xml",
-    "digestMultibase": "zQmerWC85Wg6wFl9znFCwYxApG270iEu5h6JqWAPdhyxz2dR"
-  }
-}
-          </pre>
-
-          <p>
-The next example links to the rendering template on the Web and secures it
-using the `digestMultibase` property:
-          </p>
-
-          <pre class="example nohighlight"
-              title="A remotely hosted SVG render method">
-{
-<span class="comment">...</span>
-"renderMethod": {
-  <span class="comment">// this render method is fetched from the Web</span>
-  "id": "https://degrees.example/bachelors-svg.jsonld",
-  "mediaType": "application/ld+json",
-  "type": "TemplateRenderMethod",
-  "renderSuite": "svg-mustache",
-  "digestMultibase": "zQmG270iEu5h6JqWAPdhyxz2dRerWC85Wg6wFl9znFCwYxAp"
-}
-          </pre>
-
-        </section>
-
-        <section>
-          <h3>The `pdf-mustache` Render Suite</h3>
-          <p>
-The `pdf-mustache` render suite uses the Mustache templating language to
-modify a PDF file, which is then used to render a visual representation
-of the [=verifiable credential=].
-          </p>
-
-          <p>
-In the example below, a fully embedded PDF file is used as the rendering
-template.
-          </p>
-
-          <pre class="example nohighlight"
-               title="Basic usage of the pdf-mustache render suite">
-{
-  <span class="comment">...</span>
-  "renderMethod": {
-    "type": "TemplateRenderMethod",
-    "renderSuite": "pdf-mustache",
-    <span class="comment">// this PDF file is embedded in the VC</span>
-    "template": "data:application/pdf;base64,k309SK...pwK83b"
-  }
-}
-          </pre>
-
-          <p>
-The next example links to the PDF file on the Web and secures it against
-modification by using the `digestMultibase` property.
-          </p>
-
-          <pre class="example nohighlight"
-              title="Remotely hosted PDF file for a PDF rendering template">
-{
-<span class="comment">...</span>
-"renderMethod": {
-  "type": "TemplateRenderMethod",
-  "renderSuite": "pdf-mustache",
-  "template": {
-    <span class="comment">// this PDF file is fetched from the Web</span>
-    "id": "https://degree.example/bachelors.pdf",
-    "mediaType": "application/pdf",
-    "digestMultibase": "zQmznFCwYxApG270iEu5h6JqWAPdhyxz2dRerWC85Wg6wFl9"
-  }
-}
-          </pre>
-
-          <p>
-The next example links to the rendering template on the Web and secures it
-using the `digestMultibase` property:
-          </p>
-
-          <pre class="example nohighlight"
-              title="Remotely hosted PDF rendering template">
-{
-<span class="comment">...</span>
-"renderMethod": {
-  <span class="comment">// this render method is fetched from the Web</span>
-  "id": "https://degrees.example/bachelors-pdf.jsonld",
-  "type": "TemplateRenderMethod",
-  "renderSuite": "pdf-mustache",
-  "digestMultibase": "zQmEu5h6JqWAPdhyxmz2dRerWC85Wg6wFl9znFCwYxApG270"
-}
-          </pre>
-
-        </section>
-
-        <section>
           <h3>The `json-card` Render Suite</h3>
           <p>
-The `json-card` render suite uses JSON templates to transform a
-[=verifiable credential=] into a standardized JSON card format. This format
-enables wallets to display credentials in a responsive card layout with key
-data highlighted and configurable additional fields. Wallets that implement
-this method can render the standardized JSON output in their own card UI
-designs, allowing credentials to be displayed even when a wallet doesn't
-natively support a specific credential type.
+            The `json-card` render suite uses JSON templates to transform a
+            [=verifiable credential=] into a standardized JSON card format. This format
+            enables wallets to display credentials in a responsive card layout with key
+            data highlighted and configurable additional fields. Wallets that implement
+            this method can render the standardized JSON output in their own card UI
+            designs, allowing credentials to be displayed even when a wallet doesn't
+            natively support a specific credential type.
           </p>
 
           <p>
-The template is a JSON object that matches the `json-card` output structure.
-String values in the template can be JSON pointer strings (as specified in
-[[[RFC6901]]]) that reference fields in the [=verifiable credential=]. When
-processing the template, JSON pointer strings are evaluated against the
-credential data and replaced with the resolved values. The template MUST
-conform to the JSON template schema defined below, and the resulting output
-MUST conform to the `json-card` output schema. Compound data across multiple
-fields is not supported; each field references a single JSON pointer.
+            The template is a JSON object that matches the `json-card` output structure.
+            String values in the template can be JSON pointer strings (as specified in
+            [[[RFC6901]]]) that reference fields in the [=verifiable credential=]. When
+            processing the template, JSON pointer strings are evaluated against the
+            credential data and replaced with the resolved values. The template MUST
+            conform to the JSON template schema defined below, and the resulting output
+            MUST conform to the `json-card` output schema. Compound data across multiple
+            fields is not supported; each field references a single JSON pointer.
           </p>
 
           <section>
             <h4>JSON Template Schema</h4>
             <p>
-The template for a `json-card` render suite MUST be a JSON object that
-conforms to the following structure. The template structure matches the
-output structure, but string values can be either literal strings or JSON
-pointer strings (starting with `/`) that reference fields in the
-[=verifiable credential=]. The template SHOULD be validated against this
-schema before processing.
+              The template for a `json-card` render suite MUST be a JSON object that
+              conforms to the following structure. The template structure matches the
+              output structure, but string values can be either literal strings or JSON
+              pointer strings (starting with `/`) that reference fields in the
+              [=verifiable credential=]. The template SHOULD be validated against this
+              schema before processing.
             </p>
 
             <table class="simple">
               <thead>
-                <tr>
-                  <th style="white-space: nowrap">Property</th>
-                  <th>Type</th>
-                  <th>Description</th>
-                </tr>
+              <tr>
+                <th style="white-space: nowrap">Property</th>
+                <th>Type</th>
+                <th>Description</th>
+              </tr>
               </thead>
               <tbody>
-                <tr>
-                  <td>name</td>
-                  <td>[=string=]</td>
-                  <td>
-A REQUIRED string that is either a literal display name or a JSON pointer
-string (e.g., <code>"/credentialSubject/degree/name"</code>) that references
-the credential data.
-                  </td>
-                </tr>
-                <tr>
-                  <td>description</td>
-                  <td>[=string=]</td>
-                  <td>
-A REQUIRED string that is either a literal description or a JSON pointer
-string that references the credential data.
-                  </td>
-                </tr>
-                <tr>
-                  <td>icon</td>
-                  <td>[=string=]</td>
-                  <td>
-An OPTIONAL string that is either a literal URL/data URI or a JSON pointer
-string that references the credential data.
-                  </td>
-                </tr>
-                <tr>
-                  <td>theme</td>
-                  <td>[=ordered map|map=]</td>
-                  <td>
-An OPTIONAL color theme object with the following properties:
-                    <ul>
-                      <li><code>primaryColor</code> ([=string=]): Primary color as a literal string or JSON pointer</li>
-                      <li><code>accentColor</code> ([=string=]): Accent color as a literal string or JSON pointer</li>
-                    </ul>
-                  </td>
-                </tr>
-                <tr>
-                  <td>fields</td>
-                  <td>[=list=]</td>
-                  <td>
-A REQUIRED ordered list of custom data fields. Each field is an object with:
-                    <ul>
-                      <li><code>label</code> ([=string=]): The field label (MUST be a literal string, not a JSON pointer)</li>
-                      <li><code>value</code> ([=string=]): The field value as a JSON pointer string (e.g., <code>"/issuer"</code>)</li>
-                      <li><code>language</code> ([=string=]): An OPTIONAL language tag (as specified in [[[BCP47]]]) indicating the language of the field's label and/or value</li>
-                    </ul>
-                  </td>
-                </tr>
-                <tr>
-                  <td>validFrom</td>
-                  <td>[=string=]</td>
-                  <td>
-An OPTIONAL string that is either a literal ISO 8601 date or a JSON pointer
-string that references the credential data (validity start date).
-                  </td>
-                </tr>
-                <tr>
-                  <td>validUntil</td>
-                  <td>[=string=]</td>
-                  <td>
-An OPTIONAL string that is either a literal ISO 8601 date or a JSON pointer
-string that references the credential data (validity end date).
-                  </td>
-                </tr>
+              <tr>
+                <td>name</td>
+                <td>[=string=]</td>
+                <td>
+                  A REQUIRED string that is either a literal display name or a JSON pointer
+                  string (e.g., <code>"/credentialSubject/degree/name"</code>) that references
+                  the credential data.
+                </td>
+              </tr>
+              <tr>
+                <td>description</td>
+                <td>[=string=]</td>
+                <td>
+                  A REQUIRED string that is either a literal description or a JSON pointer
+                  string that references the credential data.
+                </td>
+              </tr>
+              <tr>
+                <td>icon</td>
+                <td>[=string=]</td>
+                <td>
+                  An OPTIONAL string that is either a literal URL/data URI or a JSON pointer
+                  string that references the credential data.
+                </td>
+              </tr>
+              <tr>
+                <td>theme</td>
+                <td>[=ordered map|map=]</td>
+                <td>
+                  An OPTIONAL color theme object with the following properties:
+                  <ul>
+                    <li><code>primaryColor</code> ([=string=]): Primary color as a literal string or JSON pointer</li>
+                    <li><code>accentColor</code> ([=string=]): Accent color as a literal string or JSON pointer</li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <td>fields</td>
+                <td>[=list=]</td>
+                <td>
+                  A REQUIRED ordered list of custom data fields. Each field is an object with:
+                  <ul>
+                    <li><code>label</code> ([=string=]): The field label (MUST be a literal string, not a JSON pointer)</li>
+                    <li><code>value</code> ([=string=]): The field value as a JSON pointer string (e.g., <code>"/issuer"</code>)</li>
+                    <li><code>language</code> ([=string=]): An OPTIONAL language tag (as specified in [[[BCP47]]]) indicating the language of the field's label and/or value</li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <td>validFrom</td>
+                <td>[=string=]</td>
+                <td>
+                  An OPTIONAL string that is either a literal ISO 8601 date or a JSON pointer
+                  string that references the credential data (validity start date).
+                </td>
+              </tr>
+              <tr>
+                <td>validUntil</td>
+                <td>[=string=]</td>
+                <td>
+                  An OPTIONAL string that is either a literal ISO 8601 date or a JSON pointer
+                  string that references the credential data (validity end date).
+                </td>
+              </tr>
               </tbody>
             </table>
 
             <p>
-The following JSON Schema implements the template structure rules defined
-above:
+              The following JSON Schema implements the template structure rules defined
+              above:
             </p>
 
             <pre class="example nohighlight"
@@ -791,8 +656,8 @@ above:
             </pre>
 
             <p>
-The following example shows a valid `json-card` template with JSON pointer
-strings:
+              The following example shows a valid `json-card` template with JSON pointer
+              strings:
             </p>
 
             <pre class="example nohighlight"
@@ -829,82 +694,82 @@ strings:
           <section>
             <h4>JSON Card Output Schema</h4>
             <p>
-The output of a `json-card` template MUST be a JSON object that conforms to
-the following structure:
+              The output of a `json-card` template MUST be a JSON object that conforms to
+              the following structure:
             </p>
 
             <table class="simple">
               <thead>
-                <tr>
-                  <th style="white-space: nowrap">Property</th>
-                  <th>Type</th>
-                  <th>Description</th>
-                </tr>
+              <tr>
+                <th style="white-space: nowrap">Property</th>
+                <th>Type</th>
+                <th>Description</th>
+              </tr>
               </thead>
               <tbody>
-                <tr>
-                  <td>name</td>
-                  <td>[=string=]</td>
-                  <td>
-A REQUIRED display name for the credential card.
-                  </td>
-                </tr>
-                <tr>
-                  <td>description</td>
-                  <td>[=string=]</td>
-                  <td>
-A REQUIRED description text for the credential card.
-                  </td>
-                </tr>
-                <tr>
-                  <td>icon</td>
-                  <td>[=string=]</td>
-                  <td>
-An OPTIONAL URL or data URI for an icon or image to display on the card.
-                  </td>
-                </tr>
-                <tr>
-                  <td>theme</td>
-                  <td>[=ordered map|map=]</td>
-                  <td>
-An OPTIONAL color theme object with the following properties:
-                    <ul>
-                      <li><code>primaryColor</code> ([=string=]): Primary color for backgrounds and highlights</li>
-                      <li><code>accentColor</code> ([=string=]): Accent color for highlights and emphasis</li>
-                    </ul>
-                  </td>
-                </tr>
-                <tr>
-                  <td>fields</td>
-                  <td>[=list=]</td>
-                  <td>
-A REQUIRED ordered list of custom data fields. Each field is an object with:
-                    <ul>
-                      <li><code>label</code> ([=string=]): The field label</li>
-                      <li><code>value</code> ([=string=]): The field value</li>
-                      <li><code>language</code> ([=string=]): An OPTIONAL language tag (as specified in [[[BCP47]]]) indicating the language of the field</li>
-                    </ul>
-                  </td>
-                </tr>
-                <tr>
-                  <td>validFrom</td>
-                  <td>[=string=]</td>
-                  <td>
-An OPTIONAL ISO 8601 date string indicating when the credential becomes valid.
-                  </td>
-                </tr>
-                <tr>
-                  <td>validUntil</td>
-                  <td>[=string=]</td>
-                  <td>
-An OPTIONAL ISO 8601 date string indicating when the credential ceases to be valid.
-                  </td>
-                </tr>
+              <tr>
+                <td>name</td>
+                <td>[=string=]</td>
+                <td>
+                  A REQUIRED display name for the credential card.
+                </td>
+              </tr>
+              <tr>
+                <td>description</td>
+                <td>[=string=]</td>
+                <td>
+                  A REQUIRED description text for the credential card.
+                </td>
+              </tr>
+              <tr>
+                <td>icon</td>
+                <td>[=string=]</td>
+                <td>
+                  An OPTIONAL URL or data URI for an icon or image to display on the card.
+                </td>
+              </tr>
+              <tr>
+                <td>theme</td>
+                <td>[=ordered map|map=]</td>
+                <td>
+                  An OPTIONAL color theme object with the following properties:
+                  <ul>
+                    <li><code>primaryColor</code> ([=string=]): Primary color for backgrounds and highlights</li>
+                    <li><code>accentColor</code> ([=string=]): Accent color for highlights and emphasis</li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <td>fields</td>
+                <td>[=list=]</td>
+                <td>
+                  A REQUIRED ordered list of custom data fields. Each field is an object with:
+                  <ul>
+                    <li><code>label</code> ([=string=]): The field label</li>
+                    <li><code>value</code> ([=string=]): The field value</li>
+                    <li><code>language</code> ([=string=]): An OPTIONAL language tag (as specified in [[[BCP47]]]) indicating the language of the field</li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <td>validFrom</td>
+                <td>[=string=]</td>
+                <td>
+                  An OPTIONAL ISO 8601 date string indicating when the credential becomes valid.
+                </td>
+              </tr>
+              <tr>
+                <td>validUntil</td>
+                <td>[=string=]</td>
+                <td>
+                  An OPTIONAL ISO 8601 date string indicating when the credential ceases to be valid.
+                </td>
+              </tr>
               </tbody>
             </table>
 
             <p>
-The following example shows a valid `json-card` output:
+              The following example shows a valid `json-card` output:
             </p>
 
             <pre class="example nohighlight"
@@ -941,57 +806,57 @@ The following example shows a valid `json-card` output:
           <section>
             <h4>Template Processing</h4>
             <p>
-When processing a `json-card` template, the following steps MUST be
-performed:
+              When processing a `json-card` template, the following steps MUST be
+              performed:
             </p>
 
             <ol class="algorithm">
               <li>
-Validate the template JSON object against the JSON template schema defined
-above. If validation fails, processing MUST stop and an error MUST be
-returned.
+                Validate the template JSON object against the JSON template schema defined
+                above. If validation fails, processing MUST stop and an error MUST be
+                returned.
               </li>
               <li>
-For each string value in the template object:
+                For each string value in the template object:
                 <ol class="algorithm">
                   <li>
-If the string value starts with `/` (indicating it is a JSON pointer),
-evaluate it using the JSON Pointer algorithm [[[RFC6901]]] against the
-[=verifiable credential=] as the target document.
+                    If the string value starts with `/` (indicating it is a JSON pointer),
+                    evaluate it using the JSON Pointer algorithm [[[RFC6901]]] against the
+                    [=verifiable credential=] as the target document.
                   </li>
                   <li>
-If the JSON pointer evaluation succeeds, replace the JSON pointer string with
-the resolved value. If the resolved value is not a string, convert it to a
-string representation.
+                    If the JSON pointer evaluation succeeds, replace the JSON pointer string with
+                    the resolved value. If the resolved value is not a string, convert it to a
+                    string representation.
                   </li>
                   <li>
-If the JSON pointer evaluation fails or returns `null`, the behavior is
-implementation-specific. Implementations MAY use an empty string, leave the
-value as `null`, or signal an error.
+                    If the JSON pointer evaluation fails or returns `null`, the behavior is
+                    implementation-specific. Implementations MAY use an empty string, leave the
+                    value as `null`, or signal an error.
                   </li>
                   <li>
-If the string value does not start with `/`, treat it as a literal string
-and leave it unchanged.
+                    If the string value does not start with `/`, treat it as a literal string
+                    and leave it unchanged.
                   </li>
                 </ol>
               </li>
               <li>
-Validate the resulting JSON object against the `json-card` output schema. If
-validation fails, processing MUST stop and an error MUST be returned.
+                Validate the resulting JSON object against the `json-card` output schema. If
+                validation fails, processing MUST stop and an error MUST be returned.
               </li>
             </ol>
 
             <p>
-Note that compound data across multiple fields is not supported. Each field
-in the template references a single JSON pointer that resolves to a single
-value from the credential.
+              Note that compound data across multiple fields is not supported. Each field
+              in the template references a single JSON pointer that resolves to a single
+              value from the credential.
             </p>
 
           </section>
 
           <p>
-In the example below, a fully embedded JSON template is used as the rendering
-template. The template uses JSON pointer strings to reference credential data.
+            In the example below, a fully embedded JSON template is used as the rendering
+            template. The template uses JSON pointer strings to reference credential data.
           </p>
 
           <pre class="example nohighlight"
@@ -1008,12 +873,12 @@ template. The template uses JSON pointer strings to reference credential data.
           </pre>
 
           <p>
-The next example links to the JSON template on the Web and secures it against
-modification by using the `digestMultibase` property.
+            The next example links to the JSON template on the Web and secures it against
+            modification by using the `digestMultibase` property.
           </p>
 
           <pre class="example nohighlight"
-              title="A remotely hosted JSON template for a json-card render template">
+               title="A remotely hosted JSON template for a json-card render template">
 {
 <span class="comment">...</span>
 "renderMethod": {
@@ -1029,12 +894,12 @@ modification by using the `digestMultibase` property.
           </pre>
 
           <p>
-The next example links to the rendering template on the Web and secures it
-using the `digestMultibase` property:
+            The next example links to the rendering template on the Web and secures it
+            using the `digestMultibase` property:
           </p>
 
           <pre class="example nohighlight"
-              title="A remotely hosted json-card render method">
+               title="A remotely hosted json-card render method">
 {
 <span class="comment">...</span>
 "renderMethod": {


### PR DESCRIPTION
This PR deprecates the svg-mustache and pdf-mustache render suites because the html render suite handles both use cases now.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-render-method/pull/49.html" title="Last updated on Jul 28, 2026, 4:15 PM UTC (c26aeac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-render-method/49/7de95a9...c26aeac.html" title="Last updated on Jul 28, 2026, 4:15 PM UTC (c26aeac)">Diff</a>