### PR TITLE
Restore json-card section formatting.

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,35 +473,35 @@ information from the [=verifiable credential=] listed in `renderProperty`.
         <section>
           <h3>The `json-card` Render Suite</h3>
           <p>
-            The `json-card` render suite uses JSON templates to transform a
-            [=verifiable credential=] into a standardized JSON card format. This format
-            enables wallets to display credentials in a responsive card layout with key
-            data highlighted and configurable additional fields. Wallets that implement
-            this method can render the standardized JSON output in their own card UI
-            designs, allowing credentials to be displayed even when a wallet doesn't
-            natively support a specific credential type.
+The `json-card` render suite uses JSON templates to transform a
+[=verifiable credential=] into a standardized JSON card format. This format
+enables wallets to display credentials in a responsive card layout with key
+data highlighted and configurable additional fields. Wallets that implement
+this method can render the standardized JSON output in their own card UI
+designs, allowing credentials to be displayed even when a wallet doesn't
+natively support a specific credential type.
           </p>
 
           <p>
-            The template is a JSON object that matches the `json-card` output structure.
-            String values in the template can be JSON pointer strings (as specified in
-            [[[RFC6901]]]) that reference fields in the [=verifiable credential=]. When
-            processing the template, JSON pointer strings are evaluated against the
-            credential data and replaced with the resolved values. The template MUST
-            conform to the JSON template schema defined below, and the resulting output
-            MUST conform to the `json-card` output schema. Compound data across multiple
-            fields is not supported; each field references a single JSON pointer.
+The template is a JSON object that matches the `json-card` output structure.
+String values in the template can be JSON pointer strings (as specified in
+[[[RFC6901]]]) that reference fields in the [=verifiable credential=]. When
+processing the template, JSON pointer strings are evaluated against the
+credential data and replaced with the resolved values. The template MUST
+conform to the JSON template schema defined below, and the resulting output
+MUST conform to the `json-card` output schema. Compound data across multiple
+fields is not supported; each field references a single JSON pointer.
           </p>
 
           <section>
             <h4>JSON Template Schema</h4>
             <p>
-              The template for a `json-card` render suite MUST be a JSON object that
-              conforms to the following structure. The template structure matches the
-              output structure, but string values can be either literal strings or JSON
-              pointer strings (starting with `/`) that reference fields in the
-              [=verifiable credential=]. The template SHOULD be validated against this
-              schema before processing.
+The template for a `json-card` render suite MUST be a JSON object that
+conforms to the following structure. The template structure matches the
+output structure, but string values can be either literal strings or JSON
+pointer strings (starting with `/`) that reference fields in the
+[=verifiable credential=]. The template SHOULD be validated against this
+schema before processing.
             </p>
 
             <table class="simple">


### PR DESCRIPTION
Minor formatting-only fix.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-render-method/pull/56.html" title="Last updated on Jul 28, 2026, 4:23 PM UTC (0ec9ec6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-render-method/56/359fe25...0ec9ec6.html" title="Last updated on Jul 28, 2026, 4:23 PM UTC (0ec9ec6)">Diff</a>